### PR TITLE
Adding CI/CD *with* assets

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10.x"]
+        python-version: ["3.9.x"]
 
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest-cov
         pip install -e ./ 
-   - name: Test with pytest
+    - name: Test with pytest
       run: |
         curl -O https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
         unzip aigarmic_assets.zip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,32 @@
+name: Run tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10.x"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest-cov
+        pip install -e ./ 
+   - name: Test with pytest
+      run: |
+        curl -O https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
+        unzip aigarmic_assets.zip
+        pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: milliewalky/setup-7-zip@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -26,7 +27,6 @@ jobs:
         pip install pytest-cov
         pip install -e ./ 
     - name: Test with pytest
-      uses: milliewalky/setup-7-zip@v1
       run: |
         apt-get install 
         curl -kO https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,6 +27,6 @@ jobs:
         pip install -e ./ 
     - name: Test with pytest
       run: |
-        curl -O https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
+        curl -kO https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
         unzip aigarmic_assets.zip
         pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,9 @@ jobs:
         pip install pytest-cov
         pip install -e ./ 
     - name: Test with pytest
+      uses: milliewalky/setup-7-zip@v1
       run: |
+        apt-get install 
         curl -kO https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
-        unzip -f aigarmic_assets.zip
+        7z x aigarmic_assets.zip -aoa
         pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Test with pytest
       run: |
         curl -kO https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
-        unzip aigarmic_assets.zip
+        unzip -f aigarmic_assets.zip
         pytest

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: milliewalky/setup-7-zip@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -28,7 +27,6 @@ jobs:
         pip install -e ./ 
     - name: Test with pytest
       run: |
-        apt-get install 
         curl -kO https://datacat.liverpool.ac.uk/2631/2/aigarmic_assets.zip
         7z x aigarmic_assets.zip -aoa
         pytest


### PR DESCRIPTION
Hi @agerada,

I sniped myself over the weekend thinking about running tests for AIgarMIC, including the assets and came up with a solution that seems to work. Rather than committing the ~1GB of material to the repo, I adapted a gh-actions script that pulls the assets, unzips them, and runs all of the tests (which are currently passing). This currently takes ≈ 6 minutes to run and pass and is currently configured to run on every push to `main`. If desired, you could run it less frequently, but it may be wise to have it on every push to catch breaking changes. 

Feel free to merge this in or reject. I didn't clear it with you ahead of time, so sorry if this steps on your toes!